### PR TITLE
Use release in gen mani action

### DIFF
--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -1,6 +1,9 @@
 name: Generate manifests for demo
 on: [push]
 
+env:
+  USE_RELEASE: true
+
 jobs:
   build-and-run:
     runs-on: ubuntu-latest
@@ -14,6 +17,7 @@ jobs:
           git config --global user.email 'bot@users.noreply.github.com'
 
       - name: Download mani-diffy binary
+        if: env.USE_RELEASE == 'true'
         uses: actions/github-script@v5
         with:
           script: |
@@ -27,6 +31,11 @@ jobs:
             const downloadUrl = asset.browser_download_url
             await exec.exec('wget', ['-O', 'mani-diffy', downloadUrl])
             await exec.exec('chmod', ['+x', 'mani-diffy'])
+
+      - name: Compile
+        if: env.USE_RELEASE == 'false'
+        run: |
+          make build-binaries
 
       - name: Run for demo
         run: |

--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -2,7 +2,7 @@ name: Generate manifests for demo
 on: [push]
 
 env:
-  USE_RELEASE: true
+  USE_RELEASE: false
 
 jobs:
   build-and-run:

--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -2,7 +2,7 @@ name: Generate manifests for demo
 on: [push]
 
 env:
-  USE_RELEASE: false
+  USE_RELEASE: true
 
 jobs:
   build-and-run:

--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -7,8 +7,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          ref: v0.1.0
 
       - name: Set up Git
         run: |

--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -15,6 +15,21 @@ jobs:
           git config --global user.name 'Bot'
           git config --global user.email 'bot@users.noreply.github.com'
 
+      - name: Download mani-diffy binary
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const release = await github.rest.repos.getReleaseByTag({
+              owner,
+              repo,
+              tag: 'v0.1.0'
+            })
+            const asset = release.data.assets.find(asset => asset.name === 'mani-diffy')
+            const downloadUrl = asset.browser_download_url
+            await exec.exec('wget', ['-O', 'mani-diffy', downloadUrl])
+            await exec.exec('chmod', ['+x', 'mani-diffy'])
+
       - name: Run for demo
         run: |
           cd demo

--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          ref: v0.1.0
 
       - name: Set up Git
         run: |

--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -15,10 +15,6 @@ jobs:
           git config --global user.name 'Bot'
           git config --global user.email 'bot@users.noreply.github.com'
 
-      - name: Compile
-        run: |
-          make build-binaries
-
       - name: Run for demo
         run: |
           cd demo

--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -26,12 +26,13 @@ jobs:
             const release = await github.rest.repos.getReleaseByTag({
               owner,
               repo,
-              tag: env.RELEASE_TAG
+              tag: core.getInput('release_tag')
             })
             const asset = release.data.assets.find(asset => asset.name === 'mani-diffy')
             const downloadUrl = asset.browser_download_url
             await exec.exec('wget', ['-O', 'mani-diffy', downloadUrl])
             await exec.exec('chmod', ['+x', 'mani-diffy'])
+          release_tag: ${{ env.RELEASE_TAG }}
 
       - name: Compile
         if: env.USE_RELEASE == 'false'

--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -3,6 +3,7 @@ on: [push]
 
 env:
   USE_RELEASE: true
+  RELEASE_TAG: v0.1.0
 
 jobs:
   build-and-run:
@@ -25,7 +26,7 @@ jobs:
             const release = await github.rest.repos.getReleaseByTag({
               owner,
               repo,
-              tag: 'v0.1.0'
+              tag: env.RELEASE_TAG
             })
             const asset = release.data.assets.find(asset => asset.name === 'mani-diffy')
             const downloadUrl = asset.browser_download_url

--- a/demo/overrides/service/bar/prod.yaml
+++ b/demo/overrides/service/bar/prod.yaml
@@ -1,3 +1,3 @@
 processes:
   web:
-    replicas: 10
+    replicas: 20

--- a/demo/overrides/service/bar/prod.yaml
+++ b/demo/overrides/service/bar/prod.yaml
@@ -1,3 +1,3 @@
 processes:
   web:
-    replicas: 20
+    replicas: 10


### PR DESCRIPTION
Use release in .github/workflows/generate-manifests-demos.yaml to avoid recompiling on every push.