### PR TITLE
Skip customize files + set workdir

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,6 +210,7 @@ func PostRender(command string) PostRenderer {
 
 func main() {
 	root := flag.String("root", "bootstrap", "Directory to initially look for k8s manifests containing Argo applications. The root of the tree.")
+	workdir := flag.String("workdir", ".", "Directory to run the command in.")
 	renderDir := flag.String("output", ".zz.auto-generated", "Path to store the compiled Argo applications.")
 	maxDepth := flag.Int("max-depth", InfiniteDepth, "Maximum depth for the depth first walk.")
 	hashStore := flag.String("hash-store", "sumfile", "The hashing backend to use. Can be `sumfile` or `json`.")
@@ -221,12 +222,9 @@ func main() {
 	flag.Parse()
 
 	// Runs the command in the specified directory
-	if flag.NArg() == 1 {
-		rootPath := os.Args[len(os.Args)-1]
-		err := os.Chdir(rootPath)
-		if err != nil {
-			log.Fatal(err)
-		}
+	err := os.Chdir(*workdir)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	start := time.Now()

--- a/main.go
+++ b/main.go
@@ -157,9 +157,12 @@ func (w *Walker) Render(application *v1alpha1.Application, output string) error 
 
 	var render Renderer
 
-	// Figure out what renderer to use
+	// Figure out which renderer to use
 	if application.Spec.Source.Helm != nil {
 		render = w.HelmTemplate
+	} else if application.Spec.Source.Kustomize != nil {
+		log.Println("WARNING: kustomize not supported")
+		return nil
 	} else {
 		render = w.CopySource
 	}
@@ -212,6 +215,12 @@ func main() {
 	ignoreValueFile := flag.String("ignore-value-file", "overrides-to-ignore", "Override file to ignore based on filename")
 	postRenderer := flag.String("post-renderer", "", "When provided, binary will be called after an application is rendered.")
 	flag.Parse()
+
+	// Runs the command in the specified directory
+	if flag.NArg() == 1 {
+		rootPath := os.Args[len(os.Args)-1]
+		os.Chdir(rootPath)
+	}
 
 	start := time.Now()
 	if err := helm.VerifyRenderDir(*renderDir); err != nil {

--- a/main.go
+++ b/main.go
@@ -136,6 +136,9 @@ func (w *Walker) walk(inputPath, outputPath string, depth, maxDepth int, visited
 			if hashGenerated != hash || emptyManifest {
 				log.Printf("No match detected. Render: %s\n", crd.ObjectMeta.Name)
 				if err := w.Render(crd, path); err != nil {
+					if strings.Contains(err.Error(), "not supported") {
+						continue
+					}
 					return err
 				}
 
@@ -163,7 +166,7 @@ func (w *Walker) Render(application *v1alpha1.Application, output string) error 
 		render = w.HelmTemplate
 	case application.Spec.Source.Kustomize != nil:
 		log.Println("WARNING: kustomize not supported")
-		return nil
+		return fmt.Errorf("kustomize not supported")
 	default:
 		render = w.CopySource
 	}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ import (
 
 const InfiniteDepth = -1
 
+var ErrKustomizeNotSupported = errors.New("kustomize not supported")
+
 // Renderer is a function that can render an Argo application.
 type Renderer func(*v1alpha1.Application, string) error
 
@@ -137,7 +139,7 @@ func (w *Walker) walk(inputPath, outputPath string, depth, maxDepth int, visited
 			if hashGenerated != hash || emptyManifest {
 				log.Printf("No match detected. Render: %s\n", crd.ObjectMeta.Name)
 				if err := w.Render(crd, path); err != nil {
-					if errors.Is(err, errors.ErrUnsupported) {
+					if errors.Is(err, ErrKustomizeNotSupported) {
 						continue
 					}
 					return err
@@ -167,7 +169,7 @@ func (w *Walker) Render(application *v1alpha1.Application, output string) error 
 		render = w.HelmTemplate
 	case application.Spec.Source.Kustomize != nil:
 		log.Println("WARNING: kustomize not supported")
-		return errors.ErrUnsupported
+		return ErrKustomizeNotSupported
 	default:
 		render = w.CopySource
 	}

--- a/main.go
+++ b/main.go
@@ -158,12 +158,13 @@ func (w *Walker) Render(application *v1alpha1.Application, output string) error 
 	var render Renderer
 
 	// Figure out which renderer to use
-	if application.Spec.Source.Helm != nil {
+	switch {
+	case application.Spec.Source.Helm != nil:
 		render = w.HelmTemplate
-	} else if application.Spec.Source.Kustomize != nil {
+	case application.Spec.Source.Kustomize != nil:
 		log.Println("WARNING: kustomize not supported")
 		return nil
-	} else {
+	default:
 		render = w.CopySource
 	}
 
@@ -219,7 +220,10 @@ func main() {
 	// Runs the command in the specified directory
 	if flag.NArg() == 1 {
 		rootPath := os.Args[len(os.Args)-1]
-		os.Chdir(rootPath)
+		err := os.Chdir(rootPath)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	start := time.Now()


### PR DESCRIPTION
Skip the rendering of kustomize files, and adds the ability for users to set the work directory of the app.