### PR TITLE
Ignores generating the hash for custom path if the source is kustomize

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@ run:
   allow-parallel-runners: true
   timeout: 5m
   go: '1.20'
+  skip-dirs-use-default: false
 
 linters:
   enable:

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/1debit/mani-diffy/pkg/kustomize"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -196,6 +197,10 @@ func GenerateHash(crd *v1alpha1.Application, ignoreValueFile string) (string, er
 		return "", err
 	}
 	fmt.Fprintf(finalHash, "%x\n", crdHash)
+
+	if crd.Spec.Source.Kustomize != nil {
+		return "", kustomize.ErrNotSupported
+	}
 
 	if crd.Spec.Source.Path != "" {
 		chartHash, err := generalHashFunction(crd.Spec.Source.Path)

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -1,0 +1,7 @@
+package kustomize
+
+import (
+	"errors"
+)
+
+var ErrNotSupported = errors.New("kustomize not supported")


### PR DESCRIPTION
This also ignores the hash generation if the source is Kustomize. 

It also cleans up the custom error into a /pkg/kustomize package and makes place for later implementation of this method.