### PR TITLE
Add support for skipping Applications via annotation

### DIFF
--- a/.github/workflows/generate-manifests-demos.yaml
+++ b/.github/workflows/generate-manifests-demos.yaml
@@ -2,7 +2,7 @@ name: Generate manifests for demo
 on: [push]
 
 env:
-  USE_RELEASE: true
+  USE_RELEASE: false
   RELEASE_TAG: v0.1.1
 
 jobs:

--- a/demo/.zz.auto-generated/test-app-group-1/manifest.yaml
+++ b/demo/.zz.auto-generated/test-app-group-1/manifest.yaml
@@ -70,3 +70,29 @@ spec:
         - ../../overrides/service/foo/test.yaml
   syncPolicy:
     automated: {}
+---
+# Source: app-of-apps/templates/apps.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: test-service-skipped
+  annotations:
+    mani-diffy.chime.com/skip: "true"
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://github.com/chime/mani-diffy.git
+    path: charts/service
+    helm:
+      version: v3
+      parameters:
+      - name: env
+        value: test
+      valueFiles:
+        - ../../overrides/service/skipped/base.yaml
+        - ../../overrides/service/skipped/test.yaml
+  syncPolicy:
+    automated: {}

--- a/demo/charts/app-of-apps/templates/service.tpl
+++ b/demo/charts/app-of-apps/templates/service.tpl
@@ -5,6 +5,10 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{ .root.env }}-service-{{ $appName }}
+  {{- if .childParams.skipManiDiffy }}
+  annotations:
+    mani-diffy.chime.com/skip: "true"
+  {{- end }}
 spec:
   destination:
     namespace: argocd

--- a/demo/overrides/app-of-apps/test-app-group-1.yaml
+++ b/demo/overrides/app-of-apps/test-app-group-1.yaml
@@ -5,3 +5,6 @@ children:
     chart: service
   baz:
     chart: service
+  skipped:
+    chart: service
+    skipManiDiffy: true

--- a/main.go
+++ b/main.go
@@ -20,6 +20,22 @@ import (
 
 const InfiniteDepth = -1
 
+const renderAnnotation = "com.chime.mani-diffy/render"
+
+// shouldSkipRender checks if an Application should be skipped based on the
+// com.chime.mani-diffy/render annotation. Returns true if the annotation
+// is explicitly set to "false".
+func shouldSkipRender(app *v1alpha1.Application) bool {
+	if app.ObjectMeta.Annotations == nil {
+		return false
+	}
+	value, ok := app.ObjectMeta.Annotations[renderAnnotation]
+	if !ok {
+		return false
+	}
+	return value == "false"
+}
+
 // Renderer is a function that can render an Argo application.
 type Renderer func(*v1alpha1.Application, string) error
 
@@ -115,6 +131,12 @@ func (w *Walker) walk(inputPath, outputPath string, depth, maxDepth int, visited
 			}
 
 			if strings.HasSuffix(crd.ObjectMeta.Name, w.ignoreSuffix) {
+				continue
+			}
+
+			// Skip Applications with the com.chime.mani-diffy/render annotation set to "false"
+			if shouldSkipRender(crd) {
+				log.Printf("Skipping %s (com.chime.mani-diffy/render annotation is false)\n", crd.ObjectMeta.Name)
 				continue
 			}
 

--- a/main.go
+++ b/main.go
@@ -22,18 +22,23 @@ const InfiniteDepth = -1
 
 const skipAnnotation = "mani-diffy.chime.com/skip"
 
-// shouldSkipRender checks if an Application should be skipped based on the
-// mani-diffy.chime.com/skip annotation. Returns true if the annotation
-// is explicitly set to "true".
-func shouldSkipRender(app *v1alpha1.Application) bool {
-	if app.ObjectMeta.Annotations == nil {
-		return false
+// shouldSkipRender checks if an Application should be skipped based on:
+// 1. The application name suffix (ignoreSuffix)
+// 2. The mani-diffy.chime.com/skip annotation set to "true"
+func shouldSkipRender(app *v1alpha1.Application, ignoreSuffix string) bool {
+	// Check if the application name has the ignore suffix
+	if strings.HasSuffix(app.ObjectMeta.Name, ignoreSuffix) {
+		return true
 	}
-	value, ok := app.ObjectMeta.Annotations[skipAnnotation]
-	if !ok {
-		return false
+
+	// Check if the skip annotation is set to "true"
+	if app.ObjectMeta.Annotations != nil {
+		if value, ok := app.ObjectMeta.Annotations[skipAnnotation]; ok && value == "true" {
+			return true
+		}
 	}
-	return value == "true"
+
+	return false
 }
 
 // Renderer is a function that can render an Argo application.
@@ -130,12 +135,7 @@ func (w *Walker) walk(inputPath, outputPath string, depth, maxDepth int, visited
 				continue
 			}
 
-			if strings.HasSuffix(crd.ObjectMeta.Name, w.ignoreSuffix) {
-				continue
-			}
-
-			// Skip Applications with the mani-diffy.chime.com/skip annotation set to "true"
-			if shouldSkipRender(crd) {
+			if shouldSkipRender(crd, w.ignoreSuffix) {
 				continue
 			}
 

--- a/main.go
+++ b/main.go
@@ -136,7 +136,6 @@ func (w *Walker) walk(inputPath, outputPath string, depth, maxDepth int, visited
 
 			// Skip Applications with the mani-diffy.chime.com/skip annotation set to "true"
 			if shouldSkipRender(crd) {
-				log.Printf("Skipping %s (mani-diffy.chime.com/skip annotation is true)\n", crd.ObjectMeta.Name)
 				continue
 			}
 

--- a/main.go
+++ b/main.go
@@ -20,20 +20,20 @@ import (
 
 const InfiniteDepth = -1
 
-const renderAnnotation = "com.chime.mani-diffy/render"
+const skipAnnotation = "mani-diffy.chime.com/skip"
 
 // shouldSkipRender checks if an Application should be skipped based on the
-// com.chime.mani-diffy/render annotation. Returns true if the annotation
-// is explicitly set to "false".
+// mani-diffy.chime.com/skip annotation. Returns true if the annotation
+// is explicitly set to "true".
 func shouldSkipRender(app *v1alpha1.Application) bool {
 	if app.ObjectMeta.Annotations == nil {
 		return false
 	}
-	value, ok := app.ObjectMeta.Annotations[renderAnnotation]
+	value, ok := app.ObjectMeta.Annotations[skipAnnotation]
 	if !ok {
 		return false
 	}
-	return value == "false"
+	return value == "true"
 }
 
 // Renderer is a function that can render an Argo application.
@@ -134,9 +134,9 @@ func (w *Walker) walk(inputPath, outputPath string, depth, maxDepth int, visited
 				continue
 			}
 
-			// Skip Applications with the com.chime.mani-diffy/render annotation set to "false"
+			// Skip Applications with the mani-diffy.chime.com/skip annotation set to "true"
 			if shouldSkipRender(crd) {
-				log.Printf("Skipping %s (com.chime.mani-diffy/render annotation is false)\n", crd.ObjectMeta.Name)
+				log.Printf("Skipping %s (mani-diffy.chime.com/skip annotation is true)\n", crd.ObjectMeta.Name)
 				continue
 			}
 

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -321,7 +321,7 @@ kind: Application
 	t.Run("GenerateHashOnChart", func(t *testing.T) {
 		hash, _ := generalHashFunction("demo/charts/app-of-apps")
 		h := hex.EncodeToString(hash)
-		actualHash := "13aa148adefa3d633e5ce95584d3c95297a4417977837040cd67f0afbca17b5a"
+		actualHash := "f57ffb63de221520249492e247beb6d6f61cd378e7c246909cca9c5110a6bb28"
 		if h != actualHash {
 			t.Errorf("Failed to generate a generic hash on a chart. got: %s wanted: %s", h, actualHash)
 		}


### PR DESCRIPTION
## What

This PR adds support for skipping Applications during rendering by setting the `mani-diffy.chime.com/skip` annotation to `"true"`. This allows selective control over which Applications are processed by mani-diffy.

In most cases, this can be used as a more powerful replacement to the `-ignore-suffix` flag.

## Why

This change is needed to provide a way to exclude specific Applications from being rendered by mani-diffy. This is useful when you have Applications that should be managed differently or when you want to temporarily disable rendering for specific Applications without removing them from the repository.

## How

- Added a new constant `skipAnnotation` with the value `"mani-diffy.chime.com/skip"`
- Implemented a `shouldSkipRender()` function that checks if an Application has the annotation set to `"true"`
- Modified the `walk()` function to skip Applications that have this annotation set to `"true"`

The implementation only skips Applications when the annotation is explicitly set to `"true"`. Applications without the annotation or with any other value will continue to be rendered normally.

## References

N/A